### PR TITLE
Add CNAME with the page domain

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@
 dist: trusty
 language: java
 jdk: oraclejdk8
-script: ./docToolchain/bin/doctoolchain . generateHTML
+script:
+  - ./docToolchain/bin/doctoolchain . generateHTML
+  - echo 'hiring.picnic.tech' > target/html5/CNAME
 deploy:
   local_dir: target/html5
   provider: pages

--- a/target/html5/CNAME
+++ b/target/html5/CNAME
@@ -1,0 +1,1 @@
+hiring.picnic.tech

--- a/target/html5/CNAME
+++ b/target/html5/CNAME
@@ -1,1 +1,0 @@
-hiring.picnic.tech


### PR DESCRIPTION
Adds the CNAME file to bind the subdomain to the website.
Had to put it in the target folder, so that GitHub picks it up when deploying.