### PR TITLE
Add not expirable link to Picnic's headquarters location

### DIFF
--- a/src/pages/map.adoc
+++ b/src/pages/map.adoc
@@ -9,7 +9,7 @@ public transportation between the main destinations that will be
 relevant for you during your trip. Please bear in mind that although
 biking is the favorite method of transportation, this is not covered
 here. If you want to know how to get to the office by bike, you can use
-https://www.google.com/maps[Google Maps] and enter the following
+https://www.google.com/maps/place/Van+Marwijk+Kooystraat+15,+1114+AG+Amsterdam,+Netherlands/@52.3314517,4.9166934,17z/[Google Maps] and enter the following
 address: *Van Marwijk Kooystraat 15, 1114 AG, Amsterdam*
 
 === Amsterdam


### PR DESCRIPTION
**Motivation:**
I was scrolling on my phone, and I don't want to change windows to get to the location 

**Explanation:**
`@52.3314517,4.9166934,17z`: stands for map information (center coordinates + zoom information)
`place/Van+Marwijk+Kooystraat+15,+1114+AG+Amsterdam,+Netherlands`: the red dot(?) that we see when we select a place on maps

P.S.: Maybe adapting the text is a good idea, as the user doesn't need to enter the address.