### PR TITLE
Make google maps link directly to the HQ location

### DIFF
--- a/src/index.adoc
+++ b/src/index.adoc
@@ -1,6 +1,9 @@
 // Configure settings for asciidoc
 include::config.adoc[]
 
+// Import the uri definitions
+include::links.adoc[]
+
 // 1. Introduction
 include::pages/start.adoc[]
 

--- a/src/links.adoc
+++ b/src/links.adoc
@@ -1,0 +1,1 @@
+:url-picnic-hq-gmaps: https://goo.gl/maps/L9NHVCgeX5Cwjv7h9[Picnic HQ]

--- a/src/links.adoc
+++ b/src/links.adoc
@@ -1,1 +1,1 @@
-:url-picnic-hq-gmaps: https://goo.gl/maps/L9NHVCgeX5Cwjv7h9[Picnic HQ]
+:url-picnic-hq-gmaps: https://www.google.com/maps/search/Picnic+HQ/@52.3314517,4.9166934,17z[Picnic HQ]

--- a/src/pages/map.adoc
+++ b/src/pages/map.adoc
@@ -9,7 +9,7 @@ public transportation between the main destinations that will be
 relevant for you during your trip. Please bear in mind that although
 biking is the favorite method of transportation, this is not covered
 here. If you want to know how to get to the office by bike, you can use
-https://goo.gl/maps/L9NHVCgeX5Cwjv7h9[Google Maps].
+Google Maps {url-picnic-hq-gmaps}.
 
 === Amsterdam
 

--- a/src/pages/map.adoc
+++ b/src/pages/map.adoc
@@ -9,8 +9,7 @@ public transportation between the main destinations that will be
 relevant for you during your trip. Please bear in mind that although
 biking is the favorite method of transportation, this is not covered
 here. If you want to know how to get to the office by bike, you can use
-https://www.google.com/maps[Google Maps] and enter the following
-address: *Van Marwijk Kooystraat 15, 1114 AG, Amsterdam*
+https://goo.gl/maps/L9NHVCgeX5Cwjv7h9[Google Maps].
 
 === Amsterdam
 


### PR DESCRIPTION
~If we only use the coordinates (`@52.3314517,4.9166934,17z`) it shows the right location, but with no red dot.
If we use the location (`place/Van+Marwijk+Kooystraat+15,+1114+AG+Amsterdam,+Netherlands`) it shows the dot, but the dot is not _exactly_ Picnic HQ.
To make it refer to the exact location the link has to have the coordinates, the location and a `data` block whatever that means. The link becomes very long, so I've opted for a shortened one.
Full link: `https://www.google.com/maps/place/Picnic+HQ/@52.3313828,4.9192147,18z/data=!4m5!3m4!1s0x47c60b5f55cddecd:0x664c31f150321239!8m2!3d52.3314484!4d4.9188821`
WDYT?~

Managed to make it work with a relatively short link.

Fixes #12.